### PR TITLE
Fix resource leak in HTTP client

### DIFF
--- a/engines/engines-http/src/main/java/eu/spaziodati/batchrefine/core/http/RefineHTTPClient.java
+++ b/engines/engines-http/src/main/java/eu/spaziodati/batchrefine/core/http/RefineHTTPClient.java
@@ -129,9 +129,11 @@ public class RefineHTTPClient implements ITransformEngine {
             return;
         }
 
-        try (OutputStream oStream = outputStream(output)) {
-            IOUtils.copy(entity.getContent(), oStream);
-        }
+		try (OutputStream oStream = outputStream(output)) {
+			IOUtils.copy(entity.getContent(), oStream);
+		} finally {
+			Utils.safeClose(response);
+		}
     }
 
     private OutputStream outputStream(URL url) throws IOException {


### PR DESCRIPTION
In the `RefineHTTPClient` a `CloseableHttpResponse` is not closed during the "outputresults" step, which caused unpredictable behaviour.